### PR TITLE
Fix default Unicode alternate skip count

### DIFF
--- a/RTF Parser Kit/src/com/rtfparserkit/parser/standard/ParserState.java
+++ b/RTF Parser Kit/src/com/rtfparserkit/parser/standard/ParserState.java
@@ -37,5 +37,5 @@ class ParserState
    public int currentFont;
    public String currentEncoding;
    public String currentFontEncoding;
-   public int unicodeAlternateSkipCount;
+   public int unicodeAlternateSkipCount = 1;
 }


### PR DESCRIPTION
According to the Word2007 RTF specs page 18 for control word \ucN, the
default value is to skip one byte after a Unicode character. I was
reading weird ‚?‘ characters after German Umlauts, until I understood
what the problem is. This RTF does not contain the \ucN control word
anywhere, but relies on the default.